### PR TITLE
Chris

### DIFF
--- a/cron.js
+++ b/cron.js
@@ -1,0 +1,19 @@
+const cron = require('node-cron')
+const redis = require('redis');
+const axios = require('axios')
+const redisPort = 6379;
+const client = redis.createClient(redisPort, process.env.REDIS_URL);
+
+	const getTokens = async()=>{
+	const result = await axios.get(
+		`https://api-polygon-tokens.polygon.technology/tokenlists/allTokens.tokenlist.json`
+	);
+	result.data.tokens.forEach((token, index)=>{
+		client.zadd("tokenList", index, JSON.stringify(token))
+		client.hmset("tokenObject", token.address, JSON.stringify(token))
+	})
+	}
+cron.schedule('59 23 * * *', function() {
+	getTokens()
+  });
+	getTokens();

--- a/index.js
+++ b/index.js
@@ -78,6 +78,39 @@ app.post('/tvl', async (req, res) => {
 	}
 });
 
+app.get("/tokenMetadata", async (req, res) =>{	
+	try {
+		const {query} = req;
+		const cursor = parseInt(query.cursor)
+		const limit = parseInt(query.limit)		
+		 await client.zrange("tokenList", cursor, cursor+limit-1, async(err, data)=>{
+			if(err){
+				throw(err)			
+			}
+			res.json( data.map(token=>JSON.parse(token)))
+		}
+		);	
+}
+	catch (error) {
+		res.status(500).send({ message: err.message });
+	}})
+
+	
+app.get("/tokenMetadata/:address", async (req, res) =>{	
+	try {
+		
+		 await client.hget("tokenObject", req.params.address,  async(err, data)=>{
+			if(err){
+				throw(err)			
+			}
+			res.json({[req.params.address]: JSON.parse(data)})
+		}
+		);	
+}
+	catch (error) {
+		res.status(500).send({ message: error.message });
+	}})
+
 app.listen(PORT);
 
 console.log(`Listening on ${PORT}`);

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 	"description": "",
 	"main": "index.js",
 	"scripts": {
-		"start": "node index.js",
+		"start": "node index.js && node cron.js",
 		"start:dev": "nodemon index.js",
 		"test": "jest"
 	},
@@ -16,6 +16,7 @@
 		"cors": "^2.8.5",
 		"dotenv": "^10.0.0",
 		"express": "^4.17.1",
+		"node-cron": "^3.0.0",
 		"nodemon": "^2.0.14",
 		"redis": "^3.1.2"
 	},

--- a/yarn.lock
+++ b/yarn.lock
@@ -2492,6 +2492,18 @@ minimist@^1.2.0, minimist@^1.2.5:
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
   integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
 
+moment-timezone@^0.5.31:
+  version "0.5.34"
+  resolved "https://registry.yarnpkg.com/moment-timezone/-/moment-timezone-0.5.34.tgz#a75938f7476b88f155d3504a9343f7519d9a405c"
+  integrity sha512-3zAEHh2hKUs3EXLESx/wsgw6IQdusOT8Bxm3D9UrHPQR7zlMmzwybC8zHEM1tQ4LJwP7fcxrWr8tuBg05fFCbg==
+  dependencies:
+    moment ">= 2.9.0"
+
+"moment@>= 2.9.0":
+  version "2.29.3"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.3.tgz#edd47411c322413999f7a5940d526de183c031f3"
+  integrity sha512-c6YRvhEo//6T2Jz/vVtYzqBzwvPT95JBQ+smCytzf7c50oMZRsR/a4w88aD34I+/QVSfnoAnSBFPJHItlOMJVw==
+
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
@@ -2521,6 +2533,13 @@ negotiator@0.6.2:
   version "0.6.2"
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.2.tgz#feacf7ccf525a77ae9634436a64883ffeca346fb"
   integrity sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw==
+
+node-cron@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/node-cron/-/node-cron-3.0.0.tgz#b33252803e430f9cd8590cf85738efa1497a9522"
+  integrity sha512-DDwIvvuCwrNiaU7HEivFDULcaQualDv7KoNlB/UU1wPW0n1tDEmBJKhEIE6DlF2FuoOHcNbLJ8ITL2Iv/3AWmA==
+  dependencies:
+    moment-timezone "^0.5.31"
 
 node-int64@^0.4.0:
   version "0.4.0"


### PR DESCRIPTION
Adds chron job to cache token metadata once a day, and on deploy. Caches is it two different sets for accessing via pagination and via key respectively.
Adds `/tokenMetadata` and `/tokenMetadata/:address` routes.
 `/tokenMetadata` returns an object similar to the current `appState.tokens` object in the Frontend. 
`/tokenMetadata/:address` returns an object similar to the current `appState.tokenMetadata` object in the Frontend, but with only one address.
Adds `node-cron` dependency. Please run yarn within your container before trying to boot with this pr.